### PR TITLE
Add FastAPI CRUD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# datadog_trainning
+# Datadog Training
+
+This repository provides a simple FastAPI application that performs CRUD operations on a `Person` resource. The data is stored in memory.
+
+## Setup
+
+Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the API
+
+Run the application using `uvicorn`:
+
+```bash
+uvicorn main:app --reload
+```
+
+The API will be available at `http://localhost:8000` with automatically generated docs at `http://localhost:8000/docs`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Dict
+
+app = FastAPI()
+
+class Person(BaseModel):
+    id: int
+    name: str
+    age: int
+
+# In-memory 'database'
+people_db: Dict[int, Person] = {}
+
+@app.post("/people/", response_model=Person)
+async def create_person(person: Person):
+    if person.id in people_db:
+        raise HTTPException(status_code=400, detail="Person already exists")
+    people_db[person.id] = person
+    return person
+
+@app.get("/people/{person_id}", response_model=Person)
+async def read_person(person_id: int):
+    person = people_db.get(person_id)
+    if not person:
+        raise HTTPException(status_code=404, detail="Person not found")
+    return person
+
+@app.put("/people/{person_id}", response_model=Person)
+async def update_person(person_id: int, person: Person):
+    if person_id != person.id:
+        raise HTTPException(status_code=400, detail="ID mismatch")
+    if person_id not in people_db:
+        raise HTTPException(status_code=404, detail="Person not found")
+    people_db[person_id] = person
+    return person
+
+@app.delete("/people/{person_id}")
+async def delete_person(person_id: int):
+    if person_id not in people_db:
+        raise HTTPException(status_code=404, detail="Person not found")
+    del people_db[person_id]
+    return {"detail": "Person deleted"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- create `main.py` containing a small FastAPI app
- document how to run the API
- add dependencies in `requirements.txt`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_687831bc21c0832e838315e69f67242d