### PR TITLE
Add MySQL storage and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=password
+DB_NAME=people_db

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Datadog Training
 
-This repository provides a simple FastAPI application that performs CRUD operations on a `Person` resource. The data is stored in memory.
+This repository provides a FastAPI application instrumented with Datadog that performs CRUD operations on a `Person` resource. The data is persisted in a MySQL database and a small front‑end is provided to interact with the API.
 
 ## Setup
 
-Install the dependencies:
+1. Create a `.env` file with your database credentials. A template is provided in `.env.example`:
+
+```bash
+cp .env.example .env
+```
+
+2. Install the dependencies:
 
 ```bash
 pip install -r requirements.txt
@@ -12,10 +18,10 @@ pip install -r requirements.txt
 
 ## Running the API
 
-Run the application using `uvicorn`:
+Start the application using `uvicorn`:
 
 ```bash
 uvicorn main:app --reload
 ```
 
-The API will be available at `http://localhost:8000` with automatically generated docs at `http://localhost:8000/docs`.
+The API will be available at `http://localhost:8000`. Navigate to `http://localhost:8000` in your browser to use the simple front‑end. API documentation is available at `http://localhost:8000/docs`.

--- a/main.py
+++ b/main.py
@@ -1,59 +1,69 @@
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import Dict
+from fastapi import FastAPI, HTTPException, Depends, Request
+from typing import List
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
 from ddtrace import tracer, patch_all
 
-from typing import Dict, List
+from models import Person, PersonModel, Base, engine, get_db
 
-patch_all()
+patch_all(sqlalchemy=True, pymysql=True)
+
 app = FastAPI()
 
-class Person(BaseModel):
-    id: int
-    name: str
-    age: int
+# Datadog tracing middleware
+@app.middleware("http")
+async def trace_requests(request: Request, call_next):
+    with tracer.trace("fastapi.request", resource=request.url.path):
+        response = await call_next(request)
+        return response
 
-# In-memory 'database'
-people_db: Dict[int, Person] = {}
+@app.on_event("startup")
+def on_startup():
+    Base.metadata.create_all(bind=engine)
 
-@tracer.wrap()
+# CRUD Endpoints
 @app.post("/people/", response_model=Person)
-async def create_person(person: Person):
-    if person.id in people_db:
+def create_person(person: Person, db: Session = Depends(get_db)):
+    if db.query(PersonModel).filter(PersonModel.id == person.id).first():
         raise HTTPException(status_code=400, detail="Person already exists")
-    people_db[person.id] = person
-    return person
+    db_person = PersonModel(id=person.id, name=person.name, age=person.age)
+    db.add(db_person)
+    db.commit()
+    db.refresh(db_person)
+    return db_person
 
-
-# Endpoint to retrieve all people
-@tracer.wrap()
 @app.get("/people/", response_model=List[Person])
-async def list_people():
-    return list(people_db.values())
+def list_people(db: Session = Depends(get_db)):
+    return db.query(PersonModel).all()
 
-@tracer.wrap()
 @app.get("/people/{person_id}", response_model=Person)
-async def read_person(person_id: int):
-    person = people_db.get(person_id)
+def read_person(person_id: int, db: Session = Depends(get_db)):
+    person = db.query(PersonModel).filter(PersonModel.id == person_id).first()
     if not person:
         raise HTTPException(status_code=404, detail="Person not found")
     return person
 
-@tracer.wrap()
 @app.put("/people/{person_id}", response_model=Person)
-async def update_person(person_id: int, person: Person):
+def update_person(person_id: int, person: Person, db: Session = Depends(get_db)):
+    db_person = db.query(PersonModel).filter(PersonModel.id == person_id).first()
+    if not db_person:
+        raise HTTPException(status_code=404, detail="Person not found")
     if person_id != person.id:
         raise HTTPException(status_code=400, detail="ID mismatch")
-    if person_id not in people_db:
-        raise HTTPException(status_code=404, detail="Person not found")
-    people_db[person_id] = person
-    return person
+    db_person.name = person.name
+    db_person.age = person.age
+    db.commit()
+    db.refresh(db_person)
+    return db_person
 
-@tracer.wrap()
 @app.delete("/people/{person_id}")
-async def delete_person(person_id: int):
-    if person_id not in people_db:
+def delete_person(person_id: int, db: Session = Depends(get_db)):
+    person = db.query(PersonModel).filter(PersonModel.id == person_id).first()
+    if not person:
         raise HTTPException(status_code=404, detail="Person not found")
-    del people_db[person_id]
+    db.delete(person)
+    db.commit()
     return {"detail": "Person deleted"}
 
+# Serve frontend
+app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.orm import declarative_base, sessionmaker
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "3306")
+DB_USER = os.getenv("DB_USER", "root")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "")
+DB_NAME = os.getenv("DB_NAME", "people_db")
+
+DATABASE_URL = f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+class PersonModel(Base):
+    __tablename__ = "people"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255))
+    age = Column(Integer)
+
+class Person(BaseModel):
+    id: int
+    name: str
+    age: int
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 fastapi
 uvicorn
 pydantic
+SQLAlchemy
+pymysql
+python-dotenv
+ddtrace

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Person CRUD</title>
+    <script>
+        async function loadPeople() {
+            const res = await fetch('/people/');
+            const people = await res.json();
+            const table = document.getElementById('people');
+            table.innerHTML = '';
+            people.forEach(p => {
+                const row = document.createElement('tr');
+                row.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td>${p.age}</td><td><button onclick="deletePerson(${p.id})">Delete</button></td>`;
+                table.appendChild(row);
+            });
+        }
+
+        async function createPerson() {
+            const id = document.getElementById('id').value;
+            const name = document.getElementById('name').value;
+            const age = document.getElementById('age').value;
+            await fetch('/people/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: parseInt(id), name: name, age: parseInt(age) })
+            });
+            document.getElementById('id').value = '';
+            document.getElementById('name').value = '';
+            document.getElementById('age').value = '';
+            loadPeople();
+        }
+
+        async function deletePerson(id) {
+            await fetch('/people/' + id, { method: 'DELETE' });
+            loadPeople();
+        }
+
+        window.onload = loadPeople;
+    </script>
+</head>
+<body>
+    <h1>Person CRUD</h1>
+    <form onsubmit="createPerson(); return false;">
+        <input id="id" type="number" placeholder="ID" required>
+        <input id="name" type="text" placeholder="Name" required>
+        <input id="age" type="number" placeholder="Age" required>
+        <button type="submit">Create</button>
+    </form>
+    <table border="1">
+        <thead><tr><th>ID</th><th>Name</th><th>Age</th><th>Actions</th></tr></thead>
+        <tbody id="people"></tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move `Person` model to its own module and set up SQLAlchemy
- add MySQL connection using environment variables from `.env`
- apply Datadog tracing with a global middleware
- serve a small static front-end to interact with the CRUD API
- update dependencies and README

## Testing
- `python -m py_compile main.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_687842796404832e83ce73b825d465ea